### PR TITLE
Fixed vcs.description when debug is enabled

### DIFF
--- a/git/Plugin.php
+++ b/git/Plugin.php
@@ -100,7 +100,7 @@ class Plugin extends BasePlugin
 
                 $dir = $container->resolve('cwd');
                 $output = $container->helperExec('cd ' . escapeshellarg($dir) . ' && git describe --always --match "*.*.*" --tags HEAD');
-                if (preg_match('/(?P<version>[^\s]+)/im', $output, $m)) {
+                if (preg_match('/^(?P<version>[^\s\+]+)/im', $output, $m)) {
                     $version = $m['version'];
 
                     if ($container->isDebug()) {


### PR DESCRIPTION
The output of the helper exec will be like below when deploying with `--debug` enabled. So changed the regex to only match lines not starting with a `+`

```
+ cd /home/jochem/Code/zicht/participatiekompas.nl
+ git describe --always --match '*.*.*' --tags HEAD
1.1.3

```